### PR TITLE
Add metrics for token/detoken/inqueue

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -259,6 +259,8 @@ class Req:
         self.fill_ids = None
         self.session_id = session_id
         self.input_embeds = input_embeds
+        # Record request arrived time in queue
+        self.arrival_time = None
 
         # Sampling info
         if isinstance(sampling_params.custom_params, dict):

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -481,7 +481,13 @@ class Scheduler:
 
             batch = self.get_next_batch_to_run()
             self.cur_batch = batch
-
+            # Record queue latency for each request
+            if self.enable_metrics:
+                current_time = time.time()
+                for req in batch.reqs:
+                    if hasattr(req, "arrival_time"):
+                        queue_latency = current_time - req.arrival_time
+                        self.metrics_collector.observe_queue_latency(queue_latency)
             if batch:
                 result = self.run_batch(batch)
                 self.process_batch_result(batch, result)
@@ -585,6 +591,13 @@ class Scheduler:
 
     def process_input_requests(self, recv_reqs: List):
         for recv_req in recv_reqs:
+            # Record request arrival time
+            if isinstance(
+                recv_req, (TokenizedGenerateReqInput, TokenizedEmbeddingReqInput)
+            ):
+                arrival_time = time.time()
+                recv_req.arrival_time = arrival_time
+
             # If it is a health check generation request and there are running requests, ignore it.
             if is_health_check_generate_req(recv_req) and (
                 self.chunked_req is not None or self.running_batch is not None
@@ -640,6 +653,8 @@ class Scheduler:
                 return_hidden_states=recv_req.return_hidden_states,
                 eos_token_ids=self.model_config.hf_eos_token_id,
             )
+            # Set the arrival time from the recv_req
+            req.arrival_time = getattr(recv_req, "arrival_time", None)
             req.tokenizer = self.tokenizer
 
             if (
@@ -765,6 +780,8 @@ class Scheduler:
             recv_req.input_ids,
             recv_req.sampling_params,
         )
+        # Set the arrival time from the recv_req
+        req.arrival_time = getattr(recv_req, "arrival_time", None)
         req.tokenizer = self.tokenizer
 
         # Handle multimodal inputs
@@ -1032,6 +1049,10 @@ class Scheduler:
             )
         # Get requests from the waiting queue to a new prefill batch
         for req in self.waiting_queue:
+            if req.arrival_time is not None:
+                queue_latency = time.time() - req.arrival_time
+                self.metrics_collector.observe_request_queue_latency(queue_latency)
+
             if (
                 self.lora_paths
                 and len(

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -350,6 +350,7 @@ class TokenizerManager:
     ):
         """Tokenize one request."""
         # Start timing tokenization
+
         tokenization_start = time.time()
 
         # Tokenize
@@ -1033,7 +1034,6 @@ class TokenizerManager:
         token_logprobs_idx: List[int],
         decode_to_text: bool,
     ):
-        print(f"Stefan detokenize_top_logprobs_tokens start: {decode_to_text}")
         # TODO: The current implementation only batches the detokenization for top-k tokens per single position.
         # We should batch all top-k tokens in all positions.
         ret = []

--- a/python/sglang/srt/metrics/collector.py
+++ b/python/sglang/srt/metrics/collector.py
@@ -17,8 +17,6 @@ import time
 from dataclasses import dataclass
 from typing import Dict, Union
 
-from prometheus_client import Counter, Histogram
-
 
 @dataclass
 class SchedulerStats:
@@ -35,7 +33,7 @@ class SchedulerMetricsCollector:
 
     def __init__(self, labels: Dict[str, str]) -> None:
         # We need to import prometheus_client after setting the env variable `PROMETHEUS_MULTIPROC_DIR`
-        from prometheus_client import Gauge
+        from prometheus_client import Gauge, Histogram
 
         self.labels = labels
         self.last_log_time = time.time()
@@ -135,6 +133,7 @@ class SchedulerMetricsCollector:
 class TokenizerMetricsCollector:
     def __init__(self, labels: Dict[str, str]) -> None:
         # We need to import prometheus_client after setting the env variable `PROMETHEUS_MULTIPROC_DIR`
+        from prometheus_client import Counter, Histogram
 
         self.labels = labels
 


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation

Add metrics for token/detoken/inqueue

Radix Cache Tokens Hit Rate is already there



```bash
(venv) jobuser [ ~/sglang/sgl-kernel ]$ curl http://localhost:30000/metrics
# HELP sglang:tokenization_latency_seconds Histogram of tokenization latency in seconds
# TYPE sglang:tokenization_latency_seconds histogram
sglang:tokenization_latency_seconds_sum{model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0020227432250976562
sglang:tokenization_latency_seconds_bucket{le="0.001",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:tokenization_latency_seconds_bucket{le="0.002",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:tokenization_latency_seconds_bucket{le="0.005",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:tokenization_latency_seconds_bucket{le="0.01",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:tokenization_latency_seconds_bucket{le="0.02",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:tokenization_latency_seconds_bucket{le="0.03",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:tokenization_latency_seconds_bucket{le="0.04",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:tokenization_latency_seconds_bucket{le="0.05",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:tokenization_latency_seconds_bucket{le="0.075",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:tokenization_latency_seconds_bucket{le="0.1",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:tokenization_latency_seconds_bucket{le="0.15",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:tokenization_latency_seconds_bucket{le="0.2",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:tokenization_latency_seconds_bucket{le="0.3",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:tokenization_latency_seconds_bucket{le="0.4",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:tokenization_latency_seconds_bucket{le="0.5",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:tokenization_latency_seconds_bucket{le="1.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:tokenization_latency_seconds_bucket{le="+Inf",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:tokenization_latency_seconds_count{model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
# HELP sglang:time_to_first_token_seconds Histogram of time to first token in seconds.
# TYPE sglang:time_to_first_token_seconds histogram
sglang:time_to_first_token_seconds_sum{model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.1375048160552979
sglang:time_to_first_token_seconds_bucket{le="0.1",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
sglang:time_to_first_token_seconds_bucket{le="0.3",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
sglang:time_to_first_token_seconds_bucket{le="0.5",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_to_first_token_seconds_bucket{le="0.7",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_to_first_token_seconds_bucket{le="0.9",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:time_to_first_token_seconds_bucket{le="1.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:time_to_first_token_seconds_bucket{le="2.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:time_to_first_token_seconds_bucket{le="4.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:time_to_first_token_seconds_bucket{le="6.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:time_to_first_token_seconds_bucket{le="8.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:time_to_first_token_seconds_bucket{le="10.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:time_to_first_token_seconds_bucket{le="20.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:time_to_first_token_seconds_bucket{le="40.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:time_to_first_token_seconds_bucket{le="60.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:time_to_first_token_seconds_bucket{le="80.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:time_to_first_token_seconds_bucket{le="120.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:time_to_first_token_seconds_bucket{le="160.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:time_to_first_token_seconds_bucket{le="+Inf",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:time_to_first_token_seconds_count{model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
# HELP sglang:e2e_request_latency_seconds Histogram of End-to-end request latency in seconds
# TYPE sglang:e2e_request_latency_seconds histogram
sglang:e2e_request_latency_seconds_sum{model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.3521671295166016
sglang:e2e_request_latency_seconds_bucket{le="0.1",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
sglang:e2e_request_latency_seconds_bucket{le="0.2",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
sglang:e2e_request_latency_seconds_bucket{le="0.4",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
sglang:e2e_request_latency_seconds_bucket{le="0.8",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:e2e_request_latency_seconds_bucket{le="1.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:e2e_request_latency_seconds_bucket{le="2.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:e2e_request_latency_seconds_bucket{le="5.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:e2e_request_latency_seconds_bucket{le="10.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:e2e_request_latency_seconds_bucket{le="20.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:e2e_request_latency_seconds_bucket{le="40.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:e2e_request_latency_seconds_bucket{le="60.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:e2e_request_latency_seconds_bucket{le="80.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:e2e_request_latency_seconds_bucket{le="100.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:e2e_request_latency_seconds_bucket{le="150.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:e2e_request_latency_seconds_bucket{le="200.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:e2e_request_latency_seconds_bucket{le="250.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:e2e_request_latency_seconds_bucket{le="300.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:e2e_request_latency_seconds_bucket{le="350.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:e2e_request_latency_seconds_bucket{le="500.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:e2e_request_latency_seconds_bucket{le="1000.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:e2e_request_latency_seconds_bucket{le="+Inf",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:e2e_request_latency_seconds_count{model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
# HELP sglang:time_per_output_token_seconds Histogram of time per output token in seconds.
# TYPE sglang:time_per_output_token_seconds histogram
sglang:time_per_output_token_seconds_sum{model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.10387671140976894
sglang:time_per_output_token_seconds_bucket{le="0.002",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
sglang:time_per_output_token_seconds_bucket{le="0.005",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
sglang:time_per_output_token_seconds_bucket{le="0.01",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_per_output_token_seconds_bucket{le="0.02",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_per_output_token_seconds_bucket{le="0.03",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_per_output_token_seconds_bucket{le="0.04",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_per_output_token_seconds_bucket{le="0.05",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_per_output_token_seconds_bucket{le="0.06",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_per_output_token_seconds_bucket{le="0.07",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_per_output_token_seconds_bucket{le="0.08",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_per_output_token_seconds_bucket{le="0.09",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_per_output_token_seconds_bucket{le="0.1",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:time_per_output_token_seconds_bucket{le="0.15",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:time_per_output_token_seconds_bucket{le="0.2",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:time_per_output_token_seconds_bucket{le="0.3",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:time_per_output_token_seconds_bucket{le="0.4",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:time_per_output_token_seconds_bucket{le="0.6",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:time_per_output_token_seconds_bucket{le="0.8",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:time_per_output_token_seconds_bucket{le="1.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:time_per_output_token_seconds_bucket{le="2.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:time_per_output_token_seconds_bucket{le="+Inf",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:time_per_output_token_seconds_count{model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
# HELP sglang:inter_token_latency_seconds Histogram of inter-token latency in seconds.
# TYPE sglang:inter_token_latency_seconds histogram
sglang:inter_token_latency_seconds_sum{model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.21468138694763184
sglang:inter_token_latency_seconds_bucket{le="0.002",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
sglang:inter_token_latency_seconds_bucket{le="0.004",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
sglang:inter_token_latency_seconds_bucket{le="0.006",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
sglang:inter_token_latency_seconds_bucket{le="0.008",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 31.0
sglang:inter_token_latency_seconds_bucket{le="0.01",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 31.0
sglang:inter_token_latency_seconds_bucket{le="0.015",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 31.0
sglang:inter_token_latency_seconds_bucket{le="0.02",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 31.0
sglang:inter_token_latency_seconds_bucket{le="0.025",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 31.0
sglang:inter_token_latency_seconds_bucket{le="0.03",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 31.0
sglang:inter_token_latency_seconds_bucket{le="0.035",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 31.0
sglang:inter_token_latency_seconds_bucket{le="0.04",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 31.0
sglang:inter_token_latency_seconds_bucket{le="0.05",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 31.0
sglang:inter_token_latency_seconds_bucket{le="0.075",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 31.0
sglang:inter_token_latency_seconds_bucket{le="0.1",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 31.0
sglang:inter_token_latency_seconds_bucket{le="0.15",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 31.0
sglang:inter_token_latency_seconds_bucket{le="0.2",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 31.0
sglang:inter_token_latency_seconds_bucket{le="0.3",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 31.0
sglang:inter_token_latency_seconds_bucket{le="0.4",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 31.0
sglang:inter_token_latency_seconds_bucket{le="0.5",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 31.0
sglang:inter_token_latency_seconds_bucket{le="0.75",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 31.0
sglang:inter_token_latency_seconds_bucket{le="1.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 31.0
sglang:inter_token_latency_seconds_bucket{le="2.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 31.0
sglang:inter_token_latency_seconds_bucket{le="+Inf",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 31.0
sglang:inter_token_latency_seconds_count{model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 31.0
# HELP sglang:request_queue_latency_seconds Histogram of time requests spend in queue before processing
# TYPE sglang:request_queue_latency_seconds histogram
sglang:request_queue_latency_seconds_sum{engine_type="unified",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.00013756752014160156
sglang:request_queue_latency_seconds_bucket{engine_type="unified",le="0.001",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:request_queue_latency_seconds_bucket{engine_type="unified",le="0.002",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:request_queue_latency_seconds_bucket{engine_type="unified",le="0.005",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:request_queue_latency_seconds_bucket{engine_type="unified",le="0.01",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:request_queue_latency_seconds_bucket{engine_type="unified",le="0.02",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:request_queue_latency_seconds_bucket{engine_type="unified",le="0.05",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:request_queue_latency_seconds_bucket{engine_type="unified",le="0.1",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:request_queue_latency_seconds_bucket{engine_type="unified",le="0.2",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:request_queue_latency_seconds_bucket{engine_type="unified",le="0.5",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:request_queue_latency_seconds_bucket{engine_type="unified",le="1.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:request_queue_latency_seconds_bucket{engine_type="unified",le="2.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:request_queue_latency_seconds_bucket{engine_type="unified",le="5.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:request_queue_latency_seconds_bucket{engine_type="unified",le="10.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:request_queue_latency_seconds_bucket{engine_type="unified",le="20.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:request_queue_latency_seconds_bucket{engine_type="unified",le="30.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:request_queue_latency_seconds_bucket{engine_type="unified",le="60.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:request_queue_latency_seconds_bucket{engine_type="unified",le="+Inf",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:request_queue_latency_seconds_count{engine_type="unified",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
# HELP sglang:num_running_reqs The number of running requests.
# TYPE sglang:num_running_reqs gauge
sglang:num_running_reqs{engine_type="unified",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
# HELP sglang:num_used_tokens The number of used tokens.
# TYPE sglang:num_used_tokens gauge
sglang:num_used_tokens{engine_type="unified",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 90.0
# HELP sglang:token_usage The token usage.
# TYPE sglang:token_usage gauge
sglang:token_usage{engine_type="unified",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.00020311350433985855
# HELP sglang:gen_throughput The generation throughput (token/s).
# TYPE sglang:gen_throughput gauge
sglang:gen_throughput{engine_type="unified",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 145.66172914751175
# HELP sglang:num_queue_reqs The number of requests in the waiting queue.
# TYPE sglang:num_queue_reqs gauge
sglang:num_queue_reqs{engine_type="unified",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
# HELP sglang:cache_hit_rate The prefix cache hit rate.
# TYPE sglang:cache_hit_rate gauge
sglang:cache_hit_rate{engine_type="unified",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
# HELP sglang:spec_accept_length The average acceptance length of speculative decoding.
# TYPE sglang:spec_accept_length gauge
sglang:spec_accept_length{engine_type="unified",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
# HELP sglang:detokenization_latency_seconds Histogram of detokenization latency in seconds
# TYPE sglang:detokenization_latency_seconds histogram
sglang:detokenization_latency_seconds_sum{model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0022296905517578125
sglang:detokenization_latency_seconds_bucket{le="0.001",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 5.0
sglang:detokenization_latency_seconds_bucket{le="0.002",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 5.0
sglang:detokenization_latency_seconds_bucket{le="0.005",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 5.0
sglang:detokenization_latency_seconds_bucket{le="0.01",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 5.0
sglang:detokenization_latency_seconds_bucket{le="0.02",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 5.0
sglang:detokenization_latency_seconds_bucket{le="0.03",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 5.0
sglang:detokenization_latency_seconds_bucket{le="0.04",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 5.0
sglang:detokenization_latency_seconds_bucket{le="0.05",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 5.0
sglang:detokenization_latency_seconds_bucket{le="0.075",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 5.0
sglang:detokenization_latency_seconds_bucket{le="0.1",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 5.0
sglang:detokenization_latency_seconds_bucket{le="0.15",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 5.0
sglang:detokenization_latency_seconds_bucket{le="0.2",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 5.0
sglang:detokenization_latency_seconds_bucket{le="0.3",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 5.0
sglang:detokenization_latency_seconds_bucket{le="0.4",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 5.0
sglang:detokenization_latency_seconds_bucket{le="0.5",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 5.0
sglang:detokenization_latency_seconds_bucket{le="1.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 5.0
sglang:detokenization_latency_seconds_bucket{le="+Inf",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 5.0
sglang:detokenization_latency_seconds_count{model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 5.0
# HELP sglang:prompt_tokens_total Number of prefill tokens processed.
# TYPE sglang:prompt_tokens_total counter
sglang:prompt_tokens_total{model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 23.0
# HELP sglang:generation_tokens_total Number of generation tokens processed.
# TYPE sglang:generation_tokens_total counter
sglang:generation_tokens_total{model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 89.0
# HELP sglang:cached_tokens_total Number of cached prompt tokens.
# TYPE sglang:cached_tokens_total counter
sglang:cached_tokens_total{model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
# HELP sglang:num_requests_total Number of requests processed.
# TYPE sglang:num_requests_total counter
sglang:num_requests_total{model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
(venv) jobuser [ ~/sglang/sgl-kernel ]$ 
```
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
