### PR TITLE
Add metrics for token/detok/inqueue/radixlookup

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -266,8 +266,12 @@ class Req:
         self.fill_ids = None
         self.session_id = session_id
         self.input_embeds = input_embeds
-        # Record request arrived time in queue
-        self.arrival_time = None
+        
+        # Record Latency Breakdown
+        self.queue_time_start = None
+        self.queue_time_end = None
+        self.radix_cache_lookup_time_start = None
+        self.radix_cache_lookup_time_end = None
 
         # Sampling info
         if isinstance(sampling_params.custom_params, dict):

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -266,6 +266,8 @@ class Req:
         self.fill_ids = None
         self.session_id = session_id
         self.input_embeds = input_embeds
+        # Record request arrived time in queue
+        self.arrival_time = None
 
         # Sampling info
         if isinstance(sampling_params.custom_params, dict):

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1088,8 +1088,9 @@ class Scheduler(SchedulerOutputProcessorMixin):
                 None if prefix_computed else self.tree_cache,
                 self.enable_hierarchical_cache,
             )
-            latency = time.time() - start_time
-            self.metrics_collector.observe_prefix_cache_lookup_latency(latency)
+            if self.enable_metrics:
+                latency = time.time() - start_time
+                self.metrics_collector.observe_prefix_cache_lookup_latency(latency)
 
             res = adder.add_one_req(
                 req, self.chunked_req, self.enable_hierarchical_cache

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1082,10 +1082,14 @@ class Scheduler(SchedulerOutputProcessorMixin):
                 self.running_batch.batch_is_full = True
                 break
 
+            # Lookup Radix Cache
+            start_time = time.time()
             req.init_next_round_input(
                 None if prefix_computed else self.tree_cache,
                 self.enable_hierarchical_cache,
             )
+            latency = time.time() - start_time
+            self.metrics_collector.observe_prefix_cache_lookup_latency(latency)
 
             res = adder.add_one_req(
                 req, self.chunked_req, self.enable_hierarchical_cache

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -350,6 +350,7 @@ class TokenizerManager:
     ):
         """Tokenize one request."""
         # Start timing tokenization
+
         tokenization_start = time.time()
 
         # Tokenize
@@ -1033,7 +1034,6 @@ class TokenizerManager:
         token_logprobs_idx: List[int],
         decode_to_text: bool,
     ):
-        print(f"Stefan detokenize_top_logprobs_tokens start: {decode_to_text}")
         # TODO: The current implementation only batches the detokenization for top-k tokens per single position.
         # We should batch all top-k tokens in all positions.
         ret = []

--- a/python/sglang/srt/metrics/collector.py
+++ b/python/sglang/srt/metrics/collector.py
@@ -27,6 +27,8 @@ class SchedulerStats:
     num_queue_reqs: int = 0
     cache_hit_rate: float = 0.0
     spec_accept_length: float = 0.0
+    request_queue_latency: float = 0.0
+    prefix_cache_lookup_latency: float = 0.0
 
 
 class SchedulerMetricsCollector:
@@ -136,15 +138,6 @@ class SchedulerMetricsCollector:
         self._log_gauge(self.cache_hit_rate, stats.cache_hit_rate)
         self._log_gauge(self.spec_accept_length, stats.spec_accept_length)
         self.last_log_time = time.time()
-
-    def observe_request_queue_latency(self, latency: float):
-        """Record how long a request waited in queue before processing."""
-        self.histogram_request_queue_latency.labels(**self.labels).observe(latency)
-
-    def observe_prefix_cache_lookup_latency(self, latency: float):
-        """Record how long a request spent in prefix cache lookup."""
-        self.prefix_cache_lookup_latency.labels(**self.labels).observe(latency)
-
 
 class TokenizerMetricsCollector:
     def __init__(self, labels: Dict[str, str]) -> None:
@@ -302,13 +295,7 @@ class TokenizerMetricsCollector:
                 0.040,
                 0.050,
                 0.075,
-                0.100,
-                0.150,
-                0.200,
-                0.300,
-                0.400,
-                0.500,
-                1.000,
+                0.100
             ],
         )
 
@@ -326,13 +313,7 @@ class TokenizerMetricsCollector:
                 0.040,
                 0.050,
                 0.075,
-                0.100,
-                0.150,
-                0.200,
-                0.300,
-                0.400,
-                0.500,
-                1.000,
+                0.100
             ],
         )
 

--- a/python/sglang/srt/metrics/collector.py
+++ b/python/sglang/srt/metrics/collector.py
@@ -17,8 +17,6 @@ import time
 from dataclasses import dataclass
 from typing import Dict, Union
 
-from prometheus_client import Counter, Histogram
-
 
 @dataclass
 class SchedulerStats:
@@ -35,7 +33,7 @@ class SchedulerMetricsCollector:
 
     def __init__(self, labels: Dict[str, str]) -> None:
         # We need to import prometheus_client after setting the env variable `PROMETHEUS_MULTIPROC_DIR`
-        from prometheus_client import Gauge
+        from prometheus_client import Gauge, Histogram
 
         self.labels = labels
         self.last_log_time = time.time()
@@ -135,6 +133,7 @@ class SchedulerMetricsCollector:
 class TokenizerMetricsCollector:
     def __init__(self, labels: Dict[str, str]) -> None:
         # We need to import prometheus_client after setting the env variable `PROMETHEUS_MULTIPROC_DIR`
+        from prometheus_client import Counter, Histogram
 
         self.labels = labels
 

--- a/python/sglang/srt/metrics/collector.py
+++ b/python/sglang/srt/metrics/collector.py
@@ -102,12 +102,24 @@ class SchedulerMetricsCollector:
                 0.200,
                 0.500,
                 1.000,
-                2.000,
-                5.000,
-                10.000,
-                20.000,
-                30.000,
-                60.000,
+            ],
+        )
+
+        self.prefix_cache_lookup_latency = Histogram(
+            name="sglang:prefix_cache_lookup_latency_seconds",
+            documentation="Histogram of time requests spend in prefix cache lookup",
+            labelnames=labels.keys(),
+            buckets=[
+                0.001,
+                0.002,
+                0.005,
+                0.010,
+                0.020,
+                0.050,
+                0.100,
+                0.200,
+                0.500,
+                1.000,
             ],
         )
 
@@ -128,6 +140,10 @@ class SchedulerMetricsCollector:
     def observe_request_queue_latency(self, latency: float):
         """Record how long a request waited in queue before processing."""
         self.histogram_request_queue_latency.labels(**self.labels).observe(latency)
+
+    def observe_prefix_cache_lookup_latency(self, latency: float):
+        """Record how long a request spent in prefix cache lookup."""
+        self.prefix_cache_lookup_latency.labels(**self.labels).observe(latency)
 
 
 class TokenizerMetricsCollector:


### PR DESCRIPTION
<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->

## Motivation
Add metrics for token/detok/inqueue/radixlookup


```bash
# HELP sglang:tokenization_latency_seconds Histogram of tokenization latency in seconds
# TYPE sglang:tokenization_latency_seconds histogram
sglang:tokenization_latency_seconds_sum{model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.1920928955078125e-06
sglang:tokenization_latency_seconds_bucket{le="0.001",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:tokenization_latency_seconds_bucket{le="0.002",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:tokenization_latency_seconds_bucket{le="0.005",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:tokenization_latency_seconds_bucket{le="0.01",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:tokenization_latency_seconds_bucket{le="0.02",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:tokenization_latency_seconds_bucket{le="0.03",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:tokenization_latency_seconds_bucket{le="0.04",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:tokenization_latency_seconds_bucket{le="0.05",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:tokenization_latency_seconds_bucket{le="0.075",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:tokenization_latency_seconds_bucket{le="0.1",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:tokenization_latency_seconds_bucket{le="0.15",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:tokenization_latency_seconds_bucket{le="0.2",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:tokenization_latency_seconds_bucket{le="0.3",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:tokenization_latency_seconds_bucket{le="0.4",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:tokenization_latency_seconds_bucket{le="0.5",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:tokenization_latency_seconds_bucket{le="1.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:tokenization_latency_seconds_bucket{le="+Inf",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:tokenization_latency_seconds_count{model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
# HELP sglang:time_to_first_token_seconds Histogram of time to first token in seconds.
# TYPE sglang:time_to_first_token_seconds histogram
sglang:time_to_first_token_seconds_sum{model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.7075157165527344
sglang:time_to_first_token_seconds_bucket{le="0.1",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
sglang:time_to_first_token_seconds_bucket{le="0.3",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
sglang:time_to_first_token_seconds_bucket{le="0.5",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
sglang:time_to_first_token_seconds_bucket{le="0.7",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
sglang:time_to_first_token_seconds_bucket{le="0.9",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_to_first_token_seconds_bucket{le="1.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_to_first_token_seconds_bucket{le="2.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_to_first_token_seconds_bucket{le="4.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_to_first_token_seconds_bucket{le="6.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_to_first_token_seconds_bucket{le="8.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_to_first_token_seconds_bucket{le="10.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_to_first_token_seconds_bucket{le="20.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_to_first_token_seconds_bucket{le="40.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_to_first_token_seconds_bucket{le="60.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_to_first_token_seconds_bucket{le="80.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_to_first_token_seconds_bucket{le="120.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_to_first_token_seconds_bucket{le="160.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_to_first_token_seconds_bucket{le="+Inf",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_to_first_token_seconds_count{model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
# HELP sglang:e2e_request_latency_seconds Histogram of End-to-end request latency in seconds
# TYPE sglang:e2e_request_latency_seconds histogram
sglang:e2e_request_latency_seconds_sum{model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.7075071334838867
sglang:e2e_request_latency_seconds_bucket{le="0.1",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
sglang:e2e_request_latency_seconds_bucket{le="0.2",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
sglang:e2e_request_latency_seconds_bucket{le="0.4",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
sglang:e2e_request_latency_seconds_bucket{le="0.8",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:e2e_request_latency_seconds_bucket{le="1.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:e2e_request_latency_seconds_bucket{le="2.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:e2e_request_latency_seconds_bucket{le="5.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:e2e_request_latency_seconds_bucket{le="10.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:e2e_request_latency_seconds_bucket{le="20.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:e2e_request_latency_seconds_bucket{le="40.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:e2e_request_latency_seconds_bucket{le="60.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:e2e_request_latency_seconds_bucket{le="80.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:e2e_request_latency_seconds_bucket{le="100.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:e2e_request_latency_seconds_bucket{le="150.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:e2e_request_latency_seconds_bucket{le="200.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:e2e_request_latency_seconds_bucket{le="250.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:e2e_request_latency_seconds_bucket{le="300.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:e2e_request_latency_seconds_bucket{le="350.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:e2e_request_latency_seconds_bucket{le="500.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:e2e_request_latency_seconds_bucket{le="1000.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:e2e_request_latency_seconds_bucket{le="+Inf",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:e2e_request_latency_seconds_count{model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
# HELP sglang:time_per_output_token_seconds Histogram of time per output token in seconds.
# TYPE sglang:time_per_output_token_seconds histogram
sglang:time_per_output_token_seconds_sum{model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.033690815880185083
sglang:time_per_output_token_seconds_bucket{le="0.002",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
sglang:time_per_output_token_seconds_bucket{le="0.005",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
sglang:time_per_output_token_seconds_bucket{le="0.01",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
sglang:time_per_output_token_seconds_bucket{le="0.02",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
sglang:time_per_output_token_seconds_bucket{le="0.03",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
sglang:time_per_output_token_seconds_bucket{le="0.04",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_per_output_token_seconds_bucket{le="0.05",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_per_output_token_seconds_bucket{le="0.06",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_per_output_token_seconds_bucket{le="0.07",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_per_output_token_seconds_bucket{le="0.08",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_per_output_token_seconds_bucket{le="0.09",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_per_output_token_seconds_bucket{le="0.1",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_per_output_token_seconds_bucket{le="0.15",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_per_output_token_seconds_bucket{le="0.2",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_per_output_token_seconds_bucket{le="0.3",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_per_output_token_seconds_bucket{le="0.4",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_per_output_token_seconds_bucket{le="0.6",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_per_output_token_seconds_bucket{le="0.8",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_per_output_token_seconds_bucket{le="1.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_per_output_token_seconds_bucket{le="2.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_per_output_token_seconds_bucket{le="+Inf",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:time_per_output_token_seconds_count{model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
# HELP sglang:request_queue_latency_seconds Histogram of time requests spend in queue before processing
# TYPE sglang:request_queue_latency_seconds histogram
sglang:request_queue_latency_seconds_sum{engine_type="unified",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 8.368492126464844e-05
sglang:request_queue_latency_seconds_bucket{engine_type="unified",le="0.001",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:request_queue_latency_seconds_bucket{engine_type="unified",le="0.002",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:request_queue_latency_seconds_bucket{engine_type="unified",le="0.005",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:request_queue_latency_seconds_bucket{engine_type="unified",le="0.01",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:request_queue_latency_seconds_bucket{engine_type="unified",le="0.02",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:request_queue_latency_seconds_bucket{engine_type="unified",le="0.05",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:request_queue_latency_seconds_bucket{engine_type="unified",le="0.1",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:request_queue_latency_seconds_bucket{engine_type="unified",le="0.2",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:request_queue_latency_seconds_bucket{engine_type="unified",le="0.5",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:request_queue_latency_seconds_bucket{engine_type="unified",le="1.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:request_queue_latency_seconds_bucket{engine_type="unified",le="+Inf",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:request_queue_latency_seconds_count{engine_type="unified",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
# HELP sglang:prefix_cache_lookup_latency_seconds Histogram of time requests spend in prefix cache lookup
# TYPE sglang:prefix_cache_lookup_latency_seconds histogram
sglang:prefix_cache_lookup_latency_seconds_sum{engine_type="unified",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.00010132789611816406
sglang:prefix_cache_lookup_latency_seconds_bucket{engine_type="unified",le="0.001",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:prefix_cache_lookup_latency_seconds_bucket{engine_type="unified",le="0.002",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:prefix_cache_lookup_latency_seconds_bucket{engine_type="unified",le="0.005",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:prefix_cache_lookup_latency_seconds_bucket{engine_type="unified",le="0.01",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:prefix_cache_lookup_latency_seconds_bucket{engine_type="unified",le="0.02",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:prefix_cache_lookup_latency_seconds_bucket{engine_type="unified",le="0.05",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:prefix_cache_lookup_latency_seconds_bucket{engine_type="unified",le="0.1",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:prefix_cache_lookup_latency_seconds_bucket{engine_type="unified",le="0.2",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:prefix_cache_lookup_latency_seconds_bucket{engine_type="unified",le="0.5",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:prefix_cache_lookup_latency_seconds_bucket{engine_type="unified",le="1.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:prefix_cache_lookup_latency_seconds_bucket{engine_type="unified",le="+Inf",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
sglang:prefix_cache_lookup_latency_seconds_count{engine_type="unified",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
# HELP sglang:num_running_reqs The number of running requests.
# TYPE sglang:num_running_reqs gauge
sglang:num_running_reqs{engine_type="unified",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
# HELP sglang:num_used_tokens The number of used tokens.
# TYPE sglang:num_used_tokens gauge
sglang:num_used_tokens{engine_type="unified",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
# HELP sglang:token_usage The token usage.
# TYPE sglang:token_usage gauge
sglang:token_usage{engine_type="unified",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
# HELP sglang:gen_throughput The generation throughput (token/s).
# TYPE sglang:gen_throughput gauge
sglang:gen_throughput{engine_type="unified",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
# HELP sglang:num_queue_reqs The number of requests in the waiting queue.
# TYPE sglang:num_queue_reqs gauge
sglang:num_queue_reqs{engine_type="unified",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
# HELP sglang:cache_hit_rate The prefix cache hit rate.
# TYPE sglang:cache_hit_rate gauge
sglang:cache_hit_rate{engine_type="unified",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
# HELP sglang:spec_accept_length The average acceptance length of speculative decoding.
# TYPE sglang:spec_accept_length gauge
sglang:spec_accept_length{engine_type="unified",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
# HELP sglang:detokenization_latency_seconds Histogram of detokenization latency in seconds
# TYPE sglang:detokenization_latency_seconds histogram
sglang:detokenization_latency_seconds_sum{model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0005891323089599609
sglang:detokenization_latency_seconds_bucket{le="0.001",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:detokenization_latency_seconds_bucket{le="0.002",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:detokenization_latency_seconds_bucket{le="0.005",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:detokenization_latency_seconds_bucket{le="0.01",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:detokenization_latency_seconds_bucket{le="0.02",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:detokenization_latency_seconds_bucket{le="0.03",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:detokenization_latency_seconds_bucket{le="0.04",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:detokenization_latency_seconds_bucket{le="0.05",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:detokenization_latency_seconds_bucket{le="0.075",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:detokenization_latency_seconds_bucket{le="0.1",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:detokenization_latency_seconds_bucket{le="0.15",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:detokenization_latency_seconds_bucket{le="0.2",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:detokenization_latency_seconds_bucket{le="0.3",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:detokenization_latency_seconds_bucket{le="0.4",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:detokenization_latency_seconds_bucket{le="0.5",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:detokenization_latency_seconds_bucket{le="1.0",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:detokenization_latency_seconds_bucket{le="+Inf",model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
sglang:detokenization_latency_seconds_count{model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 2.0
# HELP sglang:prompt_tokens_total Number of prefill tokens processed.
# TYPE sglang:prompt_tokens_total counter
sglang:prompt_tokens_total{model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 91.0
# HELP sglang:generation_tokens_total Number of generation tokens processed.
# TYPE sglang:generation_tokens_total counter
sglang:generation_tokens_total{model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 21.0
# HELP sglang:cached_tokens_total Number of cached prompt tokens.
# TYPE sglang:cached_tokens_total counter
sglang:cached_tokens_total{model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 0.0
# HELP sglang:num_requests_total Number of requests processed.
# TYPE sglang:num_requests_total counter
sglang:num_requests_total{model_name="/shared/public/models/Meta-Llama-3-8B-Instruct"} 1.0
```
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Modifications

<!-- Describe the changes made in this PR. -->

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci).
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/references/contribution_guide.html#writing-documentation-running-docs-ci).
- [ ] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/references/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/references/accuracy_evaluation.html).
- [ ] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [ ] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.
